### PR TITLE
Fix compiler warning

### DIFF
--- a/lineup-parameters/lineup-parameters.c
+++ b/lineup-parameters/lineup-parameters.c
@@ -238,6 +238,8 @@ get_function_declaration_length (gchar **lines)
       nb_lines++;
       cur_line++;
     }
+  /* should not be reachable - but silences a compiler warning */
+  return 0;
 }
 
 static GSList *


### PR DESCRIPTION
The final return should not be reachable - but there is no way for
the compiler to know

Just return 0 as last fallback

Detected by openSUSE build root policy checker:
[  198s] I: Program returns random data in a function
[  198s] E: nautilus no-return-in-nonvoid-function lineup-parameters.c:241

https://bugzilla.gnome.org/show_bug.cgi?id=770652